### PR TITLE
fix error "Class Hoa\Database\Layer\pdo does not exist" when ran under ubuntu 16.04 with php7.1

### DIFF
--- a/src/Frontend/Reader.php
+++ b/src/Frontend/Reader.php
@@ -16,7 +16,7 @@ class Reader
     {
         $this->_databaseConnection = Dal::getInstance(
             'main',
-            'pdo',
+            'Pdo',
             $dsn,
             $user,
             $password


### PR DESCRIPTION
I got an error while running the project under linux, I guess it was a typo in the class name. 
I din't look deeper but it fixes the run.

`Class Hoa\Database\Layer\pdo does not exist`